### PR TITLE
fix hydration and title element received array with more than 1 element

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -37,7 +37,6 @@ const Header = ({ socials }: Props) => {
           />
         ))}
       </motion.div>
-      <Link href="#contact">
         <motion.div
           initial={{
             x: 500,
@@ -59,12 +58,12 @@ const Header = ({ socials }: Props) => {
             bgColor="transparent"
             className="cursor-pointer"
             network="email"
+            url="#contact"
           />
-          <p className="uppercase hidden md:inline-flex text-sm text-gray-400">
+          <Link href="#contact" className="uppercase hidden md:inline-flex text-sm text-gray-400">
             Get In Touch
-          </p>
+          </Link>
         </motion.div>
-      </Link>
     </header>
   );
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,10 +29,11 @@ type Props = {
 }
 
 export default function Home({ pageInfo, experiences, projects, skills, socials }: Props) {
+  const websiteTitle = `${pageInfo?.name} - Portfolio`
   return (
     <main className="bg-[rgb(36,36,36)] text-white h-screen snap-y snap-mandatory overflow-y-scroll overflow-x-hidden z-0 scrollbar scrollbar-track-gray-400/20 scrollbar-thumb-[#F7AB0A]/80">
       <Head>
-        <title>{pageInfo?.name} - Portfolio</title>
+        <title>{websiteTitle}</title>
       </Head>
 
       <Header socials={socials} />


### PR DESCRIPTION
Error-1: https://github.com/vercel/next.js/discussions/38256 
for fixing error-1, fixed at title tag to render only 1 node

Error-2: Hydration failed because the initial UI does not match what was rendered on the server
for error 2, read this: https://nextjs.org/docs/messages/react-hydration-error 
one of the comments on sonny sangha's portfolio video for solving error-2: 
"If you're getting issues with Hydration after making the Email logo clickable, its because you have nested <a/> tags.
Social Icon is a component which contains an <a/> tag and Link is just a fancy a tag, so it will complain.

I solved this by just using the url property of the social Icon and wrapping the get in touch with me text in a Link tag, which works since they are on the same level now and no longer nested."

Really helpful comment. implemented the same fix in this changes PR.
